### PR TITLE
Add web view -> cocoa bridge

### DIFF
--- a/FlashlightApp/SpotlightSIMBL/SpotlightSIMBL/_SS_InlineWebViewContainer.m
+++ b/FlashlightApp/SpotlightSIMBL/SpotlightSIMBL/_SS_InlineWebViewContainer.m
@@ -18,6 +18,46 @@
 
 @implementation _SS_InlineWebViewContainer
 
+#pragma mark Window Scripting Layer
+
+- (NSString *)bash:(NSString*) args {
+    NSPipe *pipeIn = [NSPipe pipe];
+    NSPipe *pipeOut = [NSPipe pipe];
+    NSFileHandle *file = pipeOut.fileHandleForReading;
+    
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = @"/bin/bash";
+    task.arguments = [NSArray arrayWithObjects:@"-l", @"-c", args, nil];
+    task.standardInput = pipeIn;
+    task.standardOutput = pipeOut;
+    
+    [task waitUntilExit];
+    [task launch];
+    
+    NSData *data = [file readDataToEndOfFile];
+    [file closeFile];
+    
+    NSString *grepOutput = [[NSString alloc] initWithData: data encoding: NSUTF8StringEncoding];
+    return grepOutput;
+}
+
++ (BOOL)isSelectorExcludedFromWebScript:(SEL)sel {
+    if(sel == @selector(bash:))
+        return NO;
+    return YES;
+}
+
++ (NSString *)webScriptNameForSelector:(SEL)sel {
+    if(sel == @selector(bash:))
+        return @"bash";
+    return nil;
+}
+
+- (void)webView:(WebView *)sender didClearWindowObject:(WebScriptObject *)windowScriptObject forFrame:(WebFrame *)frame
+{
+    [windowScriptObject setValue:self forKey:@"flashlight"];
+}
+
 #pragma mark Navigation interception
 
 - (void)webView:(WebView *)webView decidePolicyForNavigationAction:(NSDictionary *)actionInformation request:(NSURLRequest *)request frame:(WebFrame *)frame decisionListener:(id<WebPolicyDecisionListener>)listener {


### PR DESCRIPTION
This adds an object to `window` which makes use of the cocoa web view windowScriptObject.
It allows (currently) for bash commands to be ran via javascript like so:

``` javascript
var output = window.flashlight.bash('whoami');
// 'output' now equals current username
```

The included bash method is just a very small function made for a PoC. However, this allows full javascript to cocoa/obj-c interaction and will change plugin functionality completely.

Fixes [#117](https://github.com/nate-parrott/Flashlight/issues/117)
