### PR TITLE
Fix typo in Haomatong info.json

### DIFF
--- a/PluginDirectories/1/haomatong.bundle/info.json
+++ b/PluginDirectories/1/haomatong.bundle/info.json
@@ -5,5 +5,5 @@
 	"description": "Search for a phone number in Sogou Haomatong database",
 	"description": "在搜狗号码通数据库中搜索号码相关信息",
 	"examples": ["hmt 10086", "haomatong 10086"],
-    "categories": ["Search", "Infomation"]
+    "categories": ["Search", "Information"]
 }


### PR DESCRIPTION
One of the categories was entered as `Infomation` instead of `Information` creating an incorrectly named, duplicate category.
