### PR TITLE
Fixing capitalization of "GitHub"

### DIFF
--- a/PluginDirectories/1/github.bundle/info.json
+++ b/PluginDirectories/1/github.bundle/info.json
@@ -2,8 +2,8 @@
 	"name": "github",
 	"displayName": "GitHub Search",
 	"displayName_de": "GitHub Suche",
-	"description": "Search Github (gh).",
-	"description_de": "Durchsucht Github (gh).",
-	"examples": ["gh bootstrap", "gitub bootstrap"],
+	"description": "Search GitHub (gh).",
+	"description_de": "Durchsucht GitHub (gh).",
+	"examples": ["gh bootstrap", "github bootstrap"],
 	"categories": ["Search"]
 }


### PR DESCRIPTION
The "h" in GitHub should be capitalized. Also one of the examples was misspelled.
