### PR TITLE
Fix applescript in sublime

### DIFF
--- a/PluginDirectories/1/sublime.bundle/applescript.py
+++ b/PluginDirectories/1/sublime.bundle/applescript.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+# via http://www.leancrew.com/all-this/2013/03/combining-python-and-applescript/
+import subprocess
+
+def asrun(ascript):
+  "Run the given AppleScript and return the standard output and error."
+
+  osa = subprocess.Popen(['osascript', '-'],
+                         stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE)
+  return osa.communicate(ascript)[0]
+
+def asquote(astr):
+  "Return the AppleScript equivalent of the given string."
+
+  astr = astr.replace('"', '" & quote & "')
+  return '"{}"'.format(astr)


### PR DESCRIPTION
I accidentally deleted a file which is still needed.
I thought python on mac has a native applescript binding. :smile:
There was only a problem with the sublime command without search query.