### PR TITLE
modified description for alc dictionary plugin

### DIFF
--- a/PluginDirectories/1/alc.bundle/info.json
+++ b/PluginDirectories/1/alc.bundle/info.json
@@ -4,7 +4,7 @@
   ],
   "displayName" : "Alc 英辞郎",
   "name" : "alc",
-  "description" : "This is an example plugin",
+  "description" : "英辞郎 on the WEB検索プラグイン",
   "examples" : [
     "alc false memory",
     "eow motor skill"

--- a/PluginDirectories/1/weblio.bundle/info.json
+++ b/PluginDirectories/1/weblio.bundle/info.json
@@ -2,7 +2,7 @@
   "categories" : [
     "Language"
   ],
-  "displayName" : "weblio dictionary",
+  "displayName" : "Weblio dictionary",
   "name" : "weblio",
   "description" : "Search definition in Weblio dictionary",
   "examples" : [


### PR DESCRIPTION
I changed alc plugin's description from "this is an example plugin" to more correct one.