### PR TITLE
Fix search URL for “KickassTorrents”

### DIFF
--- a/PluginDirectories/1/torrent.bundle/plugin.py
+++ b/PluginDirectories/1/torrent.bundle/plugin.py
@@ -3,7 +3,7 @@ import urllib, json
 def results(parsed, original_query):
   search_specs = [
     ["Torrentz", "~torrentzquery", "http://torrentz.eu/search?q="],
-    ["Kickass",  "~kickassquery",  "http://kickass.so/usearch/"  ]
+    ["Kickass",  "~kickassquery",  "http://kickass.to/usearch/"  ]
   ]
 
   for name, key, url in search_specs:


### PR DESCRIPTION
Hi Nate,

this pull request changes the TLD of the search URL for “KickassTorrents” from `so` to `to`. `kickass.so` has been down for about one and a half months [[1]].

Kind regards,
  René

P.S.: Thanks for creating this super useful application.

[1]: https://torrentfreak.com/kickasstorrents-taken-domain-name-seizure-150209/