### PR TITLE
Minor Changes to the “DuckDuckGo” Plugin

### DIFF
--- a/PluginDirectories/1/duckduckgo.bundle/examples.txt
+++ b/PluginDirectories/1/duckduckgo.bundle/examples.txt
@@ -1,3 +1,4 @@
 duckduckgo search ~duckduckgoquery(query here)
 search duckduckgo for ~duckduckgoquery(query here)
 ddg ~duckduckgoquery(query here)
+\ ~duckduckgoquery(query here)

--- a/PluginDirectories/1/duckduckgo.bundle/info.json
+++ b/PluginDirectories/1/duckduckgo.bundle/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "duckduckgo",
 	"displayName": "DuckDuckGo Search",
-	"examples": ["duckduckgo Apple stock", "ddg Flashlight", "search duckduckgo for 'search term'"],
+	"examples": ["duckduckgo Apple stock", "ddg Flashlight", "\\!amg La Dispute", "search duckduckgo for 'search term'"],
 	"categories": ["Search"]
 }

--- a/PluginDirectories/1/duckduckgo.bundle/plugin.py
+++ b/PluginDirectories/1/duckduckgo.bundle/plugin.py
@@ -13,10 +13,11 @@ def results(parsed, original_query):
                   "Version/7.0 Mobile/11A465 Safari/9537.53")
     for name, key, url in search_specs:
         if key in parsed:
+            search_item = parsed[key].encode('utf_8')
             localizedurl = i18n.localstr(url)
-            search_url = localizedurl + urllib.quote_plus(parsed[key])
+            search_url = localizedurl + urllib.quote_plus(search_item)
             title = i18n.localstr("Search {0} for '{1}'").format(name,
-                                                                 parsed[key])
+                                                                 search_item)
 
             return {
                 "title": title,

--- a/PluginDirectories/1/duckduckgo.bundle/plugin.py
+++ b/PluginDirectories/1/duckduckgo.bundle/plugin.py
@@ -1,29 +1,35 @@
-import urllib, json
 import i18n
+import json
+import urllib
+
 
 def results(parsed, original_query):
 
     search_specs = [
-         ["Duck Duck Go", "~duckduckgoquery", "https://duckduckgo.com/?q="],
+        ["Duck Duck Go", "~duckduckgoquery", "https://duckduckgo.com/?q="]
     ]
+    user_agent = ("Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) " +
+                  "AppleWebKit/537.51.1 (KHTML, like Gecko) " +
+                  "Version/7.0 Mobile/11A465 Safari/9537.53")
     for name, key, url in search_specs:
         if key in parsed:
             localizedurl = i18n.localstr(url)
             search_url = localizedurl + urllib.quote_plus(parsed[key])
-            title = i18n.localstr("Search {0} for '{1}'").format(name, parsed[key]);
+            title = i18n.localstr("Search {0} for '{1}'").format(name,
+                                                                 parsed[key])
+
             return {
                 "title": title,
                 "run_args": [search_url],
-                "html": """
-                <script>
-                setTimeout(function() {
-                    window.location = %s
-                }, 500);
-                </script>
-                """%(json.dumps(search_url)),
-                "webview_user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53",
+                "html": """<script>
+                        setTimeout(function() {
+                            window.location = %s
+                        }, 500);
+                        </script>""" % (json.dumps(search_url)),
+                "webview_user_agent": user_agent,
                 "webview_links_open_in_browser": True
             }
+
 
 def run(url):
     import os


### PR DESCRIPTION
Hi,

the changes in this pull request fix an encoding error in the “DuckDuckGo” bundle. If the search query included any non ASCII characters such as `ä`, then the plugin would silently crash.

Commit 6c80127 introduces the new search keyword `\` for the bundle. I added support for this keyword since I often use the “bang syntax” to search sites, which do not have a Flashlight plugin. For example, to search for “Wenger 16999” on Amazon you can now use the search query `\!a Wenger 16999` instead of the much longer `ddg !a Wenger 16999`.

Kind regards,
  René 
