### PR TITLE
Change Bitcoin API, so that more currencies are available.

### DIFF
--- a/PluginDirectories/1/bitcoin.bundle/options.json
+++ b/PluginDirectories/1/bitcoin.bundle/options.json
@@ -1,0 +1,31 @@
+{
+    "options": [
+        {
+            "text": "Currency",
+            "type": "dropdown",
+            "key": "currency_code",
+            "options": [
+            	  {"text":"Automatic", "value" : false},
+				  {"text":"AUD", "value": "AUD"},
+				  {"text":"BRL", "value": "BRL"},
+				  {"text":"CAD", "value": "CAD"},
+				  {"text":"CHF", "value": "CHF"},
+				  {"text":"CNY", "value": "CNY"},
+				  {"text":"EUR", "value": "EUR"},
+				  {"text":"GBP", "value": "GBP"},
+				  {"text":"IDR", "value": "IDR"},
+				  {"text":"ILS", "value": "ILS"},
+				  {"text":"MXN", "value": "MXN"},
+				  {"text":"NOK", "value": "NOK"},
+				  {"text":"NZD", "value": "NZD"},
+				  {"text":"PLN", "value": "PLN"},
+				  {"text":"RON", "value": "RON"},
+				  {"text":"RUB", "value": "RUB"},
+				  {"text":"SEK", "value": "SEK"},
+				  {"text":"SGD", "value": "SGD"},
+				  {"text":"USD", "value": "USD"},
+				  {"text":"ZAR", "value": "ZAR"}
+            ]
+        }
+    ]
+}

--- a/PluginDirectories/1/bitcoin.bundle/preferences.json
+++ b/PluginDirectories/1/bitcoin.bundle/preferences.json
@@ -1,0 +1,3 @@
+{
+	"currency_code":false
+}

--- a/PluginDirectories/1/bitcoin.bundle/temp.html
+++ b/PluginDirectories/1/bitcoin.bundle/temp.html
@@ -55,10 +55,9 @@
           setTimeout(function() {
              $.ajax({
                 url: url,
-                success: function(resultText) {
-                   console.log(resultText)
-                   var res = JSON.parse(resultText);
-                   var price = res.ticker.last;
+                success: function(result) {
+                   console.log(result)
+                   var price = result.last;
                    $("#money").text(symbol + (price * count));
                 }
              })


### PR DESCRIPTION
I have changed the API used to support more currencies (see commit for details), with automatic selection from localisation settings (default), and manually but my “options.json” file does not seem to work and I’m unsure why. It validates as valid JSON, but no settings appear.

Other than that, the rest of this pull request should be working. It may need some more localisation tweaks to adjust decimal places and ordering of symbol and price, which I would be happy to do if I can get the settings fixed.