### PR TITLE
Add fntoggle plugin

### DIFF
--- a/PluginDirectories/1/fntoggle.bundle/examples.txt
+++ b/PluginDirectories/1/fntoggle.bundle/examples.txt
@@ -1,0 +1,2 @@
+fntoggle
+toggle function keys

--- a/PluginDirectories/1/fntoggle.bundle/fntoggle.applescript
+++ b/PluginDirectories/1/fntoggle.bundle/fntoggle.applescript
@@ -1,0 +1,7 @@
+tell application "System Preferences"
+    reveal anchor "keyboardTab" of pane "com.apple.preference.keyboard"
+end tell
+tell application "System Events" to tell process "System Preferences"
+    click checkbox 1 of tab group 1 of window 1
+end tell
+quit application "System Preferences"

--- a/PluginDirectories/1/fntoggle.bundle/info.json
+++ b/PluginDirectories/1/fntoggle.bundle/info.json
@@ -5,5 +5,5 @@
     "examples": ["fntoggle", "toggle function keys"],
     "categories": ["Utilities"],
     "creator_name": "Yatharth Agarwal",
-    "creator_url": "https://github.com/YatharthROCK/fntoggle"
+    "creator_url": "https://github.com/YatharthROCK/Flashlight"
 }

--- a/PluginDirectories/1/fntoggle.bundle/info.json
+++ b/PluginDirectories/1/fntoggle.bundle/info.json
@@ -1,0 +1,9 @@
+{
+    "name": "fntoggle",
+    "displayName": "Function Key Toggle",
+    "description": "Toggles the behaviour of your function keys",
+    "examples": ["fntoggle", "toggle function keys"],
+    "categories": ["Utilities"],
+    "creator_name": "Yatharth Agarwal",
+    "creator_url": "https://github.com/YatharthROCK/fntoggle"
+}

--- a/PluginDirectories/1/fntoggle.bundle/plugin.py
+++ b/PluginDirectories/1/fntoggle.bundle/plugin.py
@@ -1,0 +1,10 @@
+def results(fields, original_query):
+	return {
+		"title": "Toggle function keys",
+		"run_args": [],
+	}
+
+def run():
+	import sys, os
+	directory = os.path.dirname(__file__)
+	os.system("osascript {}/fntoggle.applescript".format(directory))


### PR DESCRIPTION
The plugin simply executes an applescript to toggle the behaviour of the function keys with and without holding <kbd>Fn</kbd>.