### PR TITLE
Change Timezone API from EarthTool to Google Time Zone.

### DIFF
--- a/PluginDirectories/1/timezone.bundle/timezone.html
+++ b/PluginDirectories/1/timezone.bundle/timezone.html
@@ -135,13 +135,22 @@
 			map = new google.maps.Map(document.getElementById('map-canvas'));
 		}
 
-		function parseDateFromResponse(responseText){
-			var time = responseText.split('\n')[10].trim().split(' ')[1];
-			return time.split(':')[0] + ':' + time.split(':')[1];
+		function parseDateFromResponse(ts, response){
+			// We pretend that the date is UTC, to avoid having to set a timezone
+			// As the date is only used within this scope, thie should be fine.
+			var utc_seconds = (ts + response.rawOffset + response.dstOffset);
+			var date = new Date(0);
+			date.setUTCSeconds(utc_seconds);
+			var hour = date.getUTCHours();
+			var minute = date.getUTCMinutes();
+			if (hour < 10) { hour = "0" + hour};
+			if (minute<10) { minute = "0" + minute};
+			return hour + ":" + minute;
 		};
-		function parseOffsetFromResponse(responseText){
-			var time = responseText.split('\n')[7].trim().split('>')[1].split('<')[0];
-			return time;
+
+		function parseOffsetFromResponse(response){
+			//This rounds to 1DP, but only if we need to as most offsets are whole hours.
+			return Math.round((response.rawOffset + response.dstOffset) / 360) / 10;
 		};
 
 		function getCoordinateFromAddress(address) {
@@ -157,11 +166,16 @@
 		}
 
 		function getTimeZoneFromCoordinates(lat, long, title){
-			var url = "http://www.earthtools.org/timezone-1.1/"+lat+"/"+long;
+			var ts = Math.round(Date.now() / 1000); //Seconds since Epoch
+			var url = "https://maps.googleapis.com/maps/api/timezone/json?location=" + lat + "," + long + "&timestamp=" + ts;
 			var xhr = new XMLHttpRequest();
 			xhr.onload=function(e){
-				
-				showResult(title, parseDateFromResponse(this.responseText), parseOffsetFromResponse(this.responseText));
+				var resp = JSON.parse(this.responseText);
+				if (resp.status==="OK") {
+					showResult(title, parseDateFromResponse(ts, resp), parseOffsetFromResponse(resp));
+				} else {
+					showError();
+				}
 			}
 			xhr.open("GET",url,true);
 			xhr.send();

--- a/PluginDirectories/1/timezone.bundle/timezone_de.html
+++ b/PluginDirectories/1/timezone.bundle/timezone_de.html
@@ -137,13 +137,22 @@
 			map = new google.maps.Map(document.getElementById('map-canvas'));
 		}
 
-		function parseDateFromResponse(responseText){
-			var time = responseText.split('\n')[10].trim().split(' ')[1];
-			return time.split(':')[0] + ':' + time.split(':')[1];
+		function parseDateFromResponse(ts, response){
+			// We pretend that the date is UTC, to avoid having to set a timezone
+			// As the date is only used within this scope, thie should be fine.
+			var utc_seconds = (ts + response.rawOffset + response.dstOffset);
+			var date = new Date(0);
+			date.setUTCSeconds(utc_seconds);
+			var hour = date.getUTCHours();
+			var minute = date.getUTCMinutes();
+			if (hour < 10) { hour = "0" + hour};
+			if (minute<10) { minute = "0" + minute};
+			return hour + ":" + minute;
 		};
-		function parseOffsetFromResponse(responseText){
-			var time = responseText.split('\n')[7].trim().split('>')[1].split('<')[0];
-			return time;
+
+		function parseOffsetFromResponse(response){
+			//This rounds to 1DP, but only if we need to as most offsets are whole hours.
+			return Math.round((response.rawOffset + response.dstOffset) / 360) / 10;
 		};
 
 		function getCoordinateFromAddress(address) {
@@ -159,11 +168,16 @@
 		}
 
 		function getTimeZoneFromCoordinates(lat, long, title){
-			var url = "http://www.earthtools.org/timezone-1.1/"+lat+"/"+long;
+			var ts = Math.round(Date.now() / 1000); //Seconds since Epoch
+			var url = "https://maps.googleapis.com/maps/api/timezone/json?location=" + lat + "," + long + "&timestamp=" + ts;
 			var xhr = new XMLHttpRequest();
 			xhr.onload=function(e){
-				
-				showResult(title, parseDateFromResponse(this.responseText), parseOffsetFromResponse(this.responseText));
+				var resp = JSON.parse(this.responseText);
+				if (resp.status==="OK") {
+					showResult(title, parseDateFromResponse(ts, resp), parseOffsetFromResponse(resp));
+				} else {
+					showError();
+				}
 			}
 			xhr.open("GET",url,true);
 			xhr.send();

--- a/PluginDirectories/1/timezone.bundle/timezone_fr.html
+++ b/PluginDirectories/1/timezone.bundle/timezone_fr.html
@@ -129,15 +129,22 @@
 			map = new google.maps.Map(document.getElementById('map-canvas'));
 		}
 
-		function parseDateFromResponse(responseText){
-			console.log(responseText);
-			var time = responseText.split('\n')[10].trim().split(' ')[1];
-			return time.split(':')[0] + ':' + time.split(':')[1];
+		function parseDateFromResponse(ts, response){
+			// We pretend that the date is UTC, to avoid having to set a timezone
+			// As the date is only used within this scope, thie should be fine.
+			var utc_seconds = (ts + response.rawOffset + response.dstOffset);
+			var date = new Date(0);
+			date.setUTCSeconds(utc_seconds);
+			var hour = date.getUTCHours();
+			var minute = date.getUTCMinutes();
+			if (hour < 10) { hour = "0" + hour};
+			if (minute<10) { minute = "0" + minute};
+			return hour + ":" + minute;
 		};
-		function parseOffsetFromResponse(responseText){
-			console.log(responseText);
-			var time = responseText.split('\n')[7].trim().split('>')[1].split('<')[0];
-			return time;
+
+		function parseOffsetFromResponse(response){
+			//This rounds to 1DP, but only if we need to as most offsets are whole hours.
+			return Math.round((response.rawOffset + response.dstOffset) / 360) / 10;
 		};
 
 		function getCoordinateFromAddress(address) {
@@ -153,11 +160,16 @@
 		}
 
 		function getTimeZoneFromCoordinates(lat, long, title){
-			var url = "http://www.earthtools.org/timezone-1.1/"+lat+"/"+long;
+			var ts = Math.round(Date.now() / 1000); //Seconds since Epoch
+			var url = "https://maps.googleapis.com/maps/api/timezone/json?location=" + lat + "," + long + "&timestamp=" + ts;
 			var xhr = new XMLHttpRequest();
 			xhr.onload=function(e){
-				
-				showResult(title, parseDateFromResponse(this.responseText), parseOffsetFromResponse(this.responseText));
+				var resp = JSON.parse(this.responseText);
+				if (resp.status==="OK") {
+					showResult(title, parseDateFromResponse(ts, resp), parseOffsetFromResponse(resp));
+				} else {
+					showError();
+				}
 			}
 			xhr.open("GET",url,true);
 			xhr.send();


### PR DESCRIPTION
The EarthTools API does not seem to always know daylight savings for a
location. This causes the incorrect time and offset to be reported, see issue #445.

To show the problems with the EarthTools API, you can go to http://www.earthtools.org and select "Helsinki". It reports daylight savings time as "unknown" when it started last month, which is presumably the problem.

This commit changes to using the [Google Time Zone API](https://developers.google.com/maps/documentation/timezone), which
knows daylight savings and provides it separately for us to take into
account.

The free API allows 2,500 requests per day, and 5 per second, which
should be more than enough.