### PR TITLE
Credit Bitcoin Average for bitcoin price data.

### DIFF
--- a/PluginDirectories/1/bitcoin.bundle/info.json
+++ b/PluginDirectories/1/bitcoin.bundle/info.json
@@ -3,7 +3,7 @@
 	"displayName": "Bitcoin Price",
 	"displayName_fr": "Prix du Bitcoin",
 	"displayName_de": "Bitcoin Preis",
-	"description": "Show latest Bitcoin price",
+	"description": "Show latest Bitcoin price from bitcoinaverage.com,
 	"description_fr": "Affiche les derniers prix du Bitcoin",
 	"description_de": "Zeigt den aktuellen Bitcoin Preis an.",
 	"examples": ["bitcoin", "btc", "2 bitcoin", "2 btc"],


### PR DESCRIPTION
After a quick email to Bitcoin Average, they have agreed that being credited in the description is acceptable as per the [terms of their API](https://bitcoinaverage.com/api), and so this change adds it for the english description. Email is quoted below.
I don't speak french or german very well, so I have left those alone.

```
from: [me]
to: bitcoinaverage@gmail.com

Hi,
I've recently updated the Flashlight[1] app's bitcoin price checker plugin to use your API. as you support a wider range of currencies.
You can see the commit here: https://github.com/nate-parrott/Flashlight/commit/2f730ef7dc7063560fae3acd7b8662219e613256
I am not the developer of Flashlight, just wanted to see the bitcoin price in my local currency.
Reading the terms of use, this seems to be OK, but please let me know if this is an issue. Would crediting you in the plugins description be acceptable?

Thanks,
Chris Hemingway
```
```
to: [me]
from: btcaverage@gmail.com

Hi Chris,

Yes thats completely fine. If we have any issues with usage we'll let you know.

Credit in description would be great also!

Many thanks,
Shaun at BitcoinAverage
```