### PR TITLE
Add settings to terminal plugin to use iTerm2

### DIFF
--- a/PluginDirectories/1/terminal.bundle/options.json
+++ b/PluginDirectories/1/terminal.bundle/options.json
@@ -1,0 +1,14 @@
+{
+    "options": [
+        {
+        	"text": "Terminal Application:",
+        	"type": "dropdown",
+        	"key":	"app",
+        	"options": [
+                {"text": "Terminal", "value": "terminal"},
+                {"text": "iTerm2", "value": "iterm2"},
+                {"text": "iTerm2.9+", "value": "iterm3"}
+            ]
+        }
+    ]
+}

--- a/PluginDirectories/1/terminal.bundle/plugin.py
+++ b/PluginDirectories/1/terminal.bundle/plugin.py
@@ -46,8 +46,10 @@ def results(parsed, original_query):
 def run(command):
     from applescript import asrun, asquote
     from pipes import quote
-    ascript = '''
-    tell application "Finder" 
+    import json
+
+    ascript_currentdir = '''
+    tell application "Finder"
          if (count of Finder windows) is not 0 then
             set currentDir to (target of front Finder window) as text
             set dir to (quoted form of POSIX path of currentDir)
@@ -55,12 +57,33 @@ def run(command):
             set dir to "~/"
         end if
     end tell
-    
-    tell application "Terminal"
-        activate
-        do script "cd " & dir
-        do script {0} in front window
-    end tell
-    '''.format(asquote(command))
+    '''
+
+    settings = json.load(open('preferences.json'))
+
+    # If the app is terminal, or _not_ iTerm2
+    if settings["app"] == "terminal" or settings["app"] not in ("iterm2", "iterm3"):
+        ascript = ascript_currentdir + '''
+        tell application "Terminal"
+            activate
+            do script "cd " & dir
+            do script {0} in front window
+        end tell
+        '''.format(asquote(command))
+    else:
+        # iTerm 2.9+ uses "window" instead of "terminal" for applescript
+        window_name = "terminal" if settings["app"] == "iterm2" else "window"
+        ascript = ascript_currentdir + '''
+        tell application "iTerm"
+            tell (make new {1})
+                    activate current session
+                    launch session "Default Session"
+                    tell the last session
+                        write text "cd " & dir
+                        write text {0}
+                    end tell
+            end tell
+        end tell
+        '''.format(asquote(command), window_name)
 
     asrun(ascript)

--- a/PluginDirectories/1/terminal.bundle/preferences.json
+++ b/PluginDirectories/1/terminal.bundle/preferences.json
@@ -1,0 +1,3 @@
+{
+  "app" : "terminal"
+}


### PR DESCRIPTION
Fixes #22 

iTerm2 and iTerm2.9 need to be separate options, as the applescript syntax has been [changed](https://iterm2.com/applescript.html) for iTerm2.9+

This commit has a slight issue with 2 iTerm windows opening if you do not already have iTerm running. This should be fixable in Applescript, but I have not been able to find out exactly how as I have never used Applescript before.