### PR TITLE
Fixes #435: Validity check of terminal plugin optional

### DIFF
--- a/PluginDirectories/1/terminal.bundle/options.json
+++ b/PluginDirectories/1/terminal.bundle/options.json
@@ -1,14 +1,19 @@
 {
     "options": [
         {
-        	"text": "Terminal Application:",
-        	"type": "dropdown",
-        	"key":	"app",
-        	"options": [
+            "text": "Terminal Application:",
+            "type": "dropdown",
+            "key":  "app",
+            "options": [
                 {"text": "Terminal", "value": "terminal"},
                 {"text": "iTerm2", "value": "iterm2"},
                 {"text": "iTerm2.9+", "value": "iterm3"}
             ]
-        }
+        },
+        {
+            "type": "checkmark",
+            "text": "Validity check",
+            "key": "validity"
+        },
     ]
 }

--- a/PluginDirectories/1/terminal.bundle/plugin.py
+++ b/PluginDirectories/1/terminal.bundle/plugin.py
@@ -23,7 +23,7 @@ def get_html(command):
   </style>
   <body>
   %s$ %s
-  
+
   <div id='hint'>
   Will be run in the directory currently open in Finder.
   </div>
@@ -31,16 +31,26 @@ def get_html(command):
   """%(getuser(), command)
 
 def results(parsed, original_query):
-    command = parsed['~command'] if parsed else original_query
-    if command[0] not in '~/.' and not is_valid_command(command.split(' ')[0]):
-        return None
+    import json
+    settings = json.load(open('preferences.json'))
+
+    command = parsed['~command'] if parsed else ' '
+    if settings["validity"]:
+        if command[0] not in '~/.' and not is_valid_command(command.split(' ')[0]):
+            return None
+        if parsed is None:
+            dict['dont_force_top_hit'] = True
+    else:
+        prefix_split = original_query.split(' ')[0]
+        prefix_char =  original_query[0]
+        if not (prefix_char == '$') and not (prefix_char == '>') and not (prefix_split == 'run'):
+            return None
+
     dict = {
         "title": "$ {0}".format(command),
         "run_args": [command],
         "html": get_html(command)
     }
-    if parsed==None:
-        dict['dont_force_top_hit'] = True
     return dict
 
 def run(command):

--- a/PluginDirectories/1/terminal.bundle/preferences.json
+++ b/PluginDirectories/1/terminal.bundle/preferences.json
@@ -1,3 +1,4 @@
 {
-  "app" : "terminal"
+  "app" : "terminal",
+  "validity" : 1
 }


### PR DESCRIPTION
If the preferences check "Validity check" is disabled the terminal plugin only checks whether the first char of the `original_query` is `$` or `>` or if the `original_query` starts with `run`. If this is the case the command is interpreted as a terminal command. In this mode the `dont_force_top_hit` is not disabled.